### PR TITLE
クエリ文字列によって英語と日本語の挨拶を出し分ける

### DIFF
--- a/src/main/java/com/example/greeting/controller/RestUsJpController.java
+++ b/src/main/java/com/example/greeting/controller/RestUsJpController.java
@@ -1,0 +1,25 @@
+package com.example.greeting.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Objects;
+
+@RestController
+public class RestUsJpController {
+
+    @GetMapping("/us-jp-hello")
+    public String hello(@RequestParam(value = "country", required = false) String country) {
+
+        // クエリ変数パスによって、レスポンスを出し分ける
+        if (Objects.equals(country, "jp")) {
+            return "こんにちは!";
+        } else if (Objects.equals(country, "us")) {
+            return "hello!";
+        } else {
+            // jp, us以外の場合は中国語で表示
+            return "bonjour!";
+        }
+    }
+}

--- a/src/main/java/com/example/greeting/controller/RestUsJpController.java
+++ b/src/main/java/com/example/greeting/controller/RestUsJpController.java
@@ -18,7 +18,7 @@ public class RestUsJpController {
         } else if (Objects.equals(country, "us")) {
             return "hello!";
         } else {
-            // jp, us以外の場合は中国語で表示
+            // jp, us以外の場合はフランス語で表示
             return "bonjour!";
         }
     }


### PR DESCRIPTION
# 概要 

## クエリ文字列によって、英語と日本語の挨拶をレスポンスとして返す内容を出し分ける

## path:http://localhost:8080/us-jp-hello?country=us / http://localhost:8080/us-jp-hello?country=jp


## 動作確認
![44A7F421-FA61-401F-B3C2-C1A2B4384308_1_201_a](https://github.com/yoko-newDeveloper/raiseTech-course-task6/assets/91002836/71cf4be5-78d3-4a99-a13f-9bd83f571a01)

![FAE5CC6A-F393-470F-A03A-405C453883DE_1_201_a](https://github.com/yoko-newDeveloper/raiseTech-course-task6/assets/91002836/67f3057f-d231-4ff1-acbc-14d35ebd5172)

![843E5058-3151-4C96-8D26-E4031E5FA3E1_1_201_a](https://github.com/yoko-newDeveloper/raiseTech-course-task6/assets/91002836/b00e589a-9dd7-4011-9479-f8d244b895c1)
